### PR TITLE
58 use same db for both cli and web

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ src/als-tools.ui.web/obj/*
 ravendb-license.json
 publish-cli.sh
 publish-web.sh
+src/DbData/*

--- a/src/als-tools.ui.cli/appsettings.json
+++ b/src/als-tools.ui.cli/appsettings.json
@@ -1,14 +1,18 @@
 {
     "DbOptions": {
-        "DataLocation": "RavenDbData",
+        "DataLocation": "../../../../DbData",
         "ServerUrl": "http://localhost:8099",
         "DocumentStoreName": "AlsToolsEmbeddedDocumentStore"
     },
     "PlugInfoOptions": {
         "InputFilePath": "~/Documents/Desenvolvimento/repos/als-tools/extras/pluginfo/all-plugins-pluginfo.txt",
         "PluginPathOptions": {
-            "Vst2Paths": [ "/Library/Audio/Plug-Ins/VST/" ],
-            "Vst3Paths": [ "/Library/Audio/Plug-Ins/VST3/" ],
+            "Vst2Paths": [
+                "/Library/Audio/Plug-Ins/VST/"
+            ],
+            "Vst3Paths": [
+                "/Library/Audio/Plug-Ins/VST3/"
+            ],
             "AudioUnitPaths": [
                 "~/Library/Audio/Plug-Ins/Components/",
                 "/Library/Audio/Plug-Ins/Components/"

--- a/src/als-tools.ui.web/als-tools.ui.web.csproj
+++ b/src/als-tools.ui.web/als-tools.ui.web.csproj
@@ -14,7 +14,7 @@
     <ProjectReference Include="..\als-tools.infrastructure\als-tools.infrastructure.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Radzen.Blazor" Version="4.32.8" />
+    <PackageReference Include="Radzen.Blazor" Version="4.33.2" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.1" />
     <PackageReference Include="Serilog.Sinks.Async" Version="2.0.0" />
   </ItemGroup>

--- a/src/als-tools.ui.web/appsettings.json
+++ b/src/als-tools.ui.web/appsettings.json
@@ -30,7 +30,7 @@
   },
   "AllowedHosts": "*",
   "DbOptions": {
-    "DataLocation": "RavenDbData",
+    "DataLocation": "../../../../DbData",
     "ServerUrl": "http://localhost:8099",
     "DocumentStoreName": "AlsToolsEmbeddedDocumentStore"
   },


### PR DESCRIPTION
Closes #58.

Now both Web and Cli projects share the same DB by default. This is achieved by setting the DB folder to a higher level in the folders hierarchy. However, it's not currently possible yet to use both CLI and Web at the same time.